### PR TITLE
app.pyからMySQLへの接続と、挿入をできるようにした

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,7 +11,7 @@ idna==3.4
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
-mysql-connector-python-rf==2.2.2
+mysql-connector-python
 mysqlclient==2.2.6
 Naked==0.1.31
 pycparser==2.21

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.3
+FROM mysql:8.0
 
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_DATABASE=todo_db
@@ -7,4 +7,4 @@ ENV MYSQL_PASSWORD=password
 
 COPY init.sql /docker-entrypoint-initdb.d/init.sql
 
-EXPOSE 3306
+COPY my.cnf /etc/mysql/conf.d/my.cnf

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,4 +1,6 @@
-CREATE TABLE tasks (
+ALTER USER 'user'@'%' IDENTIFIED WITH mysql_native_password BY 'password';
+
+CREATE TABLE IF NOT EXISTS tasks (
     id INT AUTO_INCREMENT PRIMARY KEY,
     content VARCHAR(255) NOT NULL,
     completed BOOLEAN NOT NULL DEFAULT FALSE

--- a/db/my.cnf
+++ b/db/my.cnf
@@ -1,0 +1,12 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+default-authentication-plugin=mysql_native_password
+skip-character-set-client-handshake
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,12 @@ services:
       MYSQL_DATABASE: todo_db
       MYSQL_USER: user
       MYSQL_PASSWORD: password
+      MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
+      - ./db/my.cnf:/etc/mysql/conf.d/my.cnf
 
 volumes:
   db_data:


### PR DESCRIPTION
### やったこと
1. app.pyにMySQLとのコネクト用の関数を作成した（get_db_connection）
2. app.pyにPOSTリクエストでtasksのデータを受け取る関数を作成した（add_task）
3. app.pyにadd_taskで受け取ったデータをMySQLに挿入する関数を作成した（insert_task）
4. dbディレクトリに、my.cnfファイルを作成した（文字化け防止）
5. app.pyにレスポンス内の文字化け防止のためのコードを追記した（6行目）

<img width="533" alt="image" src="https://github.com/user-attachments/assets/197789f0-727f-483f-81ea-5d409bae112a" />


### 挙動確認のための手順
1. git fetchでリポジトリの情報を持ってくる（feature/mysql-connectブランチ）
2. checkoutで移動する
3. docker-compose.ymlファイルがあるディレクトリで`docker-compose up --build`を実行
4. 以下のcurlコマンドを実行（別シェルで）
`curl -X POST -H "Content-Type: application/json" \
-d '{"content":"宿題をする","completed":false}' \
http://localhost:8080/add-task`
5. MySQLのコンテナの中に入る（`docker exec -it mysql_container mysql -u root -p`パスワードは`root`）
7. テーブルの中にデータが挿入されているか確認する